### PR TITLE
Filter parsed trades by since date

### DIFF
--- a/ingestion/house/ingest.py
+++ b/ingestion/house/ingest.py
@@ -433,6 +433,20 @@ def main():
             continue
 
         norm = parse_pdf_for_trades(pdf_bytes, f.doc_id, f"{f.first} {f.last}".strip())
+        if since:
+            kept_rows = []
+            for row in norm:
+                date_txt = row.get("date", "")
+                try:
+                    row_date = dt.date.fromisoformat(date_txt)
+                except Exception:
+                    # If a row somehow lacks a parsable date, drop it when a
+                    # --since filter is provided. These rows are rare and the
+                    # caller explicitly requested a date range.
+                    continue
+                if row_date >= since:
+                    kept_rows.append(row)
+            norm = kept_rows
         if not norm:
             sys.stderr.write(f"[INFO] No trade-like rows found in {f.pdf_url}. Skipping.\n")
             continue


### PR DESCRIPTION
## Summary
- filter parsed trade rows by the --since argument so early transactions are excluded
- drop rows lacking a parsable trade date when a lower bound is requested

## Testing
- python ingestion/house/ingest.py --xml ingestion/house/2025FD.xml --since 2025-09-15 --filing-types P --out-json /tmp/out.json

------
https://chatgpt.com/codex/tasks/task_e_68dc92cc787c83248b8baaa96726d740