### PR TITLE
Add psycopg2-binary dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ lxml==5.3.0
 pandas==2.2.2
 pyarrow==16.1.0
 doppler==0.3
+psycopg2-binary==2.9.10


### PR DESCRIPTION
## Summary
- add psycopg2-binary to requirements so environments without pg_config can install dependencies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0406a9a58832484afb0c3240abf66